### PR TITLE
Move SiteNav from Root.jsx to SiteHeader

### DIFF
--- a/src/components/SiteHeader/SiteHeader.jsx
+++ b/src/components/SiteHeader/SiteHeader.jsx
@@ -1,9 +1,15 @@
 import React from "react";
 
+import SiteNav from "../SiteNav/SiteNav";
 import styles from "./SiteHeader.module.css";
 
 function SiteHeader() {
-	return <div className={styles.wrapper}>Logo</div>;
+	return (
+		<header className={styles.wrapper}>
+			<p>Logo</p>
+			<SiteNav />
+		</header>
+	);
 }
 
 export default SiteHeader;

--- a/src/views/Root.jsx
+++ b/src/views/Root.jsx
@@ -3,14 +3,12 @@ import React from "react";
 import MainContent from "../components/MainContent/MainContent";
 import SiteFooter from "../components/SiteFooter/SiteFooter";
 import SiteHeader from "../components/SiteHeader/SiteHeader";
-import SiteNav from "../components/SiteNav/SiteNav";
 import styles from "./Root.module.css";
 
 function Root() {
 	return (
 		<div className={styles.wrapper}>
 			<SiteHeader />
-			<SiteNav />
 			<MainContent />
 			<SiteFooter />
 		</div>


### PR DESCRIPTION
As discussed in the call, this should make the styling easier as we need a wrapper anyway. Also improves semantics.