### PR TITLE
Add styling to Ask page

### DIFF
--- a/src/views/Ask/Ask.jsx
+++ b/src/views/Ask/Ask.jsx
@@ -10,13 +10,12 @@ function Ask() {
 			{/* Hero container content needs to overlap header */}
 			<div className={styles.herocontainer}>
 				<h1 className={styles.h1}>Ask PetSynth</h1>
-				<p className={styles.herotitle}>
+				<p className={styles.herodesc}>
 					Post an open-ended question here and see some suggestions
 					from our specially trained PetSynth AI...
 				</p>
 			</div>
 			<AskForm />
-			{/* Div container and extra button needed here for Results content */}
 			<AskResults />
 		</div>
 	);

--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -1,5 +1,4 @@
 /* Mobile styling */
-
 .wrapper {
 	background: white;
 	width: 100%;
@@ -7,6 +6,7 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
+	box-sizing: border-box;
 }
 
 /* Conditional colour rendering for character countdown */
@@ -30,13 +30,20 @@
 }
 
 .h1 {
-	margin-top: -25rem;
+	margin-top: -28rem;
 	color: white;
 }
 
 .herotitle {
 	color: white;
 	font-size: 20px;
+	text-align: center;
+}
+
+.herodesc {
+	color: white;
+	margin-bottom: 50px;
+	font-size: 18px;
 }
 
 /* Ask page container styling */
@@ -53,6 +60,8 @@
 	z-index: 20px;
 	background-color: white;
 	width: 100%;
+	/* border: 2px solid orange; */
+	overflow: hidden;
 }
 
 .input {
@@ -65,15 +74,22 @@
 }
 
 .title {
-	font-size: 25px;
+	font-size: 26px;
+	color: #1b1c22;
+	padding-top: 20px;
+	margin-bottom: 5px;
 }
 
 .buttonContainer {
 	display: flex;
 	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 15px;
 }
 
-.askbtn {
+.askbtn,
+.suggestbtn {
 	width: 400px;
 	padding: 10px;
 	background: #8900ff;
@@ -81,6 +97,7 @@
 	color: white;
 	border-radius: 5px;
 	border: 2px solid #8900ff;
+	font-weight: bold;
 }
 
 .askbtn:hover {
@@ -92,34 +109,128 @@
 	text-align: left;
 	font-size: 14px;
 	font-style: italic;
+	margin-left: 15px;
+}
+
+.suggestbtn {
+	display: none;
+}
+
+/* Results container */
+
+.resultslist {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	padding: 10px;
+	border-top: 1px dashed #7d7d7d;
+}
+
+.resultsContainer {
+	border: 2px solid #e7e7e7;
+	padding: 20px;
+	margin: 10px;
+	display: flex;
+	flex-direction: column;
+	border-radius: 5px;
+}
+
+.resultsContainer:hover {
+	border: 2px solid #7d7d7d;
+}
+
+.resultsTitle {
+	color: black;
+	padding: 0px;
+	margin: 0px;
+}
+
+.resultsheading {
+	color: #1b1c22;
+}
+
+.resultsDesc {
+	margin: 0px;
+}
+
+.showmorebtn {
+	border: 2px solid #e7e7e7;
+	padding: 15px;
+	border-radius: 5px;
+	color: #8900ff;
+	background: white;
+	font-weight: bold;
+	margin-bottom: 20px;
+	margin-top: 10px;
+}
+
+.showmorebtn:hover,
+.suggestbtn:hover {
+	border: 2px solid #8900ff;
+}
+
+.suggestbtn {
+	background: white;
+	color: #8900ff;
+	border: 2px solid #e7e7e7;
 }
 
 /* Desktop styling */
 @media (min-width: 768px) {
+	/* Ask Page Desktop styling */
 	.h1 {
 		font-size: 40px;
 	}
+
+	.herodesc {
+		padding-bottom: 100px;
+	}
+
+	.resultsheading {
+		color: #1b1c22;
+		margin: 0px;
+	}
+
+	.resultsDesc {
+		margin-top: 5px;
+		margin-bottom: 0px;
+		color: #1b1c22;
+	}
+
 	.resultsTitle {
-		color: black;
+		margin: 0px;
+		color: #1b1c22;
 	}
 
 	.askcontainer {
 		display: flex;
 		flex-direction: column;
+		justify-content: center;
+		align-items: center;
 		border-radius: 10px;
 		padding: 20px;
-		width: 1000px;
+		max-width: 1000px;
 		box-shadow: 0px 0px 20px 0px rgba(27, 28, 34, 0.1);
-		margin-bottom: 100px;
-		margin-top: -50px;
+		margin-bottom: 0px;
+		margin-top: -180px;
 		z-index: 20px;
 		background-color: white;
+		/* border: 2px solid green; */
+	}
+
+	.suggestbtn {
+		width: 180px;
+		display: none;
 	}
 
 	.buttonAndRemaining {
 		display: flex;
 		flex-direction: row-reverse;
-		gap: 460px;
+		justify-content: space-between;
+		gap: 200px;
+		/* border: 1px solid orange; */
+		padding-right: 10px;
 	}
 	.buttonContainer {
 		flex-direction: row-reverse;
@@ -136,5 +247,28 @@
 	.title {
 		font-size: 16px;
 		margin-right: 660px;
+	}
+
+	/* Results desktop styling */
+
+	.resultslist {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		/* border: 1px solid purple; */
+		width: 1000px;
+		box-shadow: 0px 0px 20px 0px rgba(27, 28, 34, 0.1);
+		border-radius: 5px;
+	}
+
+	.resultsContainer {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		text-align: left;
+		width: 800px;
+		height: 120px;
+		margin: 10px;
 	}
 }

--- a/src/views/Ask/AskForm.jsx
+++ b/src/views/Ask/AskForm.jsx
@@ -31,7 +31,7 @@ const AskForm = () => {
 						<button
 							type="button"
 							onClick={handleSuggestClick}
-							className={styles.askbtn}
+							className={styles.suggestbtn}
 						>
 							Suggest a Question
 						</button>

--- a/src/views/Ask/AskResults.jsx
+++ b/src/views/Ask/AskResults.jsx
@@ -20,22 +20,27 @@ function AskResults() {
 		return state.ask.responses;
 	});
 	return (
-		<div>
+		<>
 			{results && (
-				<>
-					<h3 className={styles.resultsTitle}>Results</h3>
+				<div className={styles.resultslist}>
+					<h3 className={styles.resultsheading}>Results</h3>
 					{results.map((result, index) => (
 						<ResultItem
 							key={`${result.title}-${index}`}
 							{...result}
 						/>
 					))}
-					<button type="button" onClick={handleShowMore}>
+
+					<button
+						type="button"
+						onClick={handleShowMore}
+						className={styles.showmorebtn}
+					>
 						Show more
 					</button>
-				</>
+				</div>
 			)}
-		</div>
+		</>
 	);
 
 	function handleShowMore() {


### PR DESCRIPTION
I have added styling for the Ask page for the required mobile and desktop views. I have just had a call with Pete and demo'd this to him live on a shared screen and he said it's looking great and that it would be best for us to get this approved and merged in straight away. 

**Desktop:** 
1. <img width="1512" alt="Screenshot 2024-05-23 at 12 25 07" src="https://github.com/technative-academy/PetSynth/assets/156936136/b7b5c1f9-4764-40ed-914d-39db3a154aa6">

Desktop: 

3. <img width="1512" alt="Screenshot 2024-05-23 at 12 25 40" src="https://github.com/technative-academy/PetSynth/assets/156936136/ef5b8852-30bd-4a5c-9557-25fb81346708">

Desktop: 

4. <img width="1512" alt="Screenshot 2024-05-23 at 12 25 45" src="https://github.com/technative-academy/PetSynth/assets/156936136/76606778-987e-4b1d-8899-116f5559d1ca">

**Mobile:** 

<img width="494" alt="Screenshot 2024-05-23 at 12 29 56" src="https://github.com/technative-academy/PetSynth/assets/156936136/ffb48371-58a4-4942-a008-1a277ac01ed1">

Mobile: 

<img width="498" alt="Screenshot 2024-05-23 at 12 26 55" src="https://github.com/technative-academy/PetSynth/assets/156936136/9195984b-ba44-4f0d-a55d-ed5b728f716f">

Mobile: 

<img width="499" alt="Screenshot 2024-05-23 at 12 27 06" src="https://github.com/technative-academy/PetSynth/assets/156936136/308187c7-e724-4e3a-b62c-b60816ca033a">
