### PR TITLE
Add new gradient and button styling

### DIFF
--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -9,7 +9,7 @@
 	justify-content: space-between;
 	color: white;
 	height: 40vh;
-	background: linear-gradient(-45deg, #8900ff, #f50179, #8900ff, #f50179);
+	background: linear-gradient(-45deg, #8900ff, #ffd700, #2e8b57, #8900ff);
 	background-size: 400% 400%;
 	animation: gradient 22s ease infinite;
 }

--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -241,7 +241,8 @@
 	}
 
 	.askbtn {
-		width: 180px;
+		height: 3rem;
+		width: 11rem;
 	}
 
 	.title {

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -51,10 +51,7 @@ function Home() {
 						suggestions from our specially trained
 						<span className={styles.purpleP}> PetSynth </span>.
 					</h4>
-					<button className={styles.Ask}>
-						Ask
-						<span className={styles.buttonBold}> PetSynth </span>
-					</button>
+					<button className={styles.Ask}>Ask PetSynth</button>
 				</div>
 
 				<div className={styles.contentBoxFive}>

--- a/src/views/Home/Home.module.css
+++ b/src/views/Home/Home.module.css
@@ -64,6 +64,17 @@ p {
 	color: white;
 	background-color: #8900ff;
 	border-radius: 5px;
+	border: 2px solid #8900ff;
+	font-weight: bold;
+}
+
+.Ask:hover {
+	background: #6e00cc;
+	border: 2px solid #8900ff;
+}
+
+.Ask:active {
+	border: 2px solid #6e00cc;
 }
 
 .Visit {
@@ -76,6 +87,16 @@ p {
 	color: #8900ff;
 	background-color: #fff;
 	border-radius: 5px;
+	border: 2px solid #e7e7e7;
+	font-weight: bold;
+}
+
+.Visit:hover {
+	border: 2px solid #8900ff;
+}
+
+.Visit:active {
+	border: 2px solid #6e00cc;
 }
 
 .wrapper {


### PR DESCRIPTION
Have added the approved gradient header (using the original purple colour from Pete’s brief as well as the yellow and green) as agreed on the group call and slack earlier. It makes the website look really cool! 

I have also made the button stylings consistent, matching how they are on Pete’s brief.

Image: 
<img width="1512" alt="Screenshot 2024-05-23 at 15 08 46" src="https://github.com/technative-academy/PetSynth/assets/156936136/97bb3d1a-ca12-458c-bcdf-cf1775cd78f8">
 
Image: 
<img width="1512" alt="Screenshot 2024-05-23 at 15 09 15" src="https://github.com/technative-academy/PetSynth/assets/156936136/1e17dfb8-4e48-4154-8a9b-805d15c98bed">

Image: 
<img width="1512" alt="Screenshot 2024-05-23 at 15 08 01" src="https://github.com/technative-academy/PetSynth/assets/156936136/fbaad31d-23d7-47e8-b4d9-ed177f65daff">

Image: 
<img width="1512" alt="Screenshot 2024-05-23 at 15 52 09" src="https://github.com/technative-academy/PetSynth/assets/156936136/de6ddd82-d9af-4a77-b9d9-ee72e8385695">

