### PR TITLE
Add functionality to ask page buttons

### DIFF
--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -105,6 +105,10 @@
 	border: 2px solid #8900ff;
 }
 
+.askbtn:disabled {
+	opacity: 0.3;
+}
+
 .characters {
 	text-align: left;
 	font-size: 14px;

--- a/src/views/Ask/AskForm.jsx
+++ b/src/views/Ask/AskForm.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { fetchResponses } from "../../store";
 import styles from "./Ask.module.css";
@@ -11,6 +11,13 @@ const AskForm = () => {
 	const charRemaining = useMemo(() => {
 		return 160 - questionInput.length;
 	}, [questionInput]);
+
+	const isLoading = useSelector((state) => {
+		return state.ask.pending;
+	});
+
+	const submitIsDisabled =
+		questionInput.length === 0 || questionInput.length > 160 || isLoading;
 
 	return (
 		<div className={styles.askcontainer}>
@@ -25,8 +32,12 @@ const AskForm = () => {
 				></input>
 				<div className={styles.buttonAndRemaining}>
 					<div className={styles.buttonContainer}>
-						<button type="submit" className={styles.askbtn}>
-							Ask PetSynth
+						<button
+							type="submit"
+							className={styles.askbtn}
+							disabled={submitIsDisabled}
+						>
+							{isLoading ? "Loading" : "Ask PetSynth"}
 						</button>
 						<button
 							type="button"


### PR DESCRIPTION
Pete helped me add in some cool functionality to the buttons on the Ask page. 

1. The Ask PetSynth button is disabled (opacity) when there is no input: 
<img width="1059" alt="disabled" src="https://github.com/technative-academy/PetSynth/assets/156936136/2b9ed74f-52d8-4f99-b254-fa63774ceb6b">

2. The Ask PetSynth button is not disabled when the user inputs text into the input: 
<img width="1047" alt="withtext" src="https://github.com/technative-academy/PetSynth/assets/156936136/6f0cab5c-2318-495a-b519-20220eb96af1">

3. The button is disabled when there is more than 160 characters in the input: 
<img width="1086" alt="over160" src="https://github.com/technative-academy/PetSynth/assets/156936136/9470a261-cd61-441b-9c33-7c8eb759303e">

4. The Ask PetSynth button says "Loading" after the user clicks it to ask a question and waits for the results: 
<img width="948" alt="enter" src="https://github.com/technative-academy/PetSynth/assets/156936136/4d887bf4-c295-4b9d-b7e9-0e6e8153a51e">
