### PR TITLE
Fix Shop Show More Button Incorrectly Showing

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -98,7 +98,10 @@ const productsSlice = createSlice({
 		builder.addCase(fetchProducts.fulfilled, (state, action) => {
 			if (action.payload.isQuerySpecified) {
 				state.results = action.payload.results;
-				state.gotAllResults = action.payload.query["page-size"] == null; // If unspecified, all results will be returned by the API
+				state.gotAllResults =
+					action.payload.query["page-size"] == null ||
+					action.payload.results.length <
+						action.payload.query["page-size"]; // If unspecified, all results will be returned by the API
 			} else {
 				state.results.push(
 					...action.payload.results.filter(


### PR DESCRIPTION
Previously if a query had less than the page size results, it would show. It now doesn't since this condition means there can't be any more results.

Example: this query returns 1 result, so the button no longer shows
![image](https://github.com/technative-academy/PetSynth/assets/16543008/d0eecbdb-f53c-41f8-a098-647de1278e33)
