### PR TITLE
Reduce Motion

### DIFF
--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -80,3 +80,9 @@
 		flex: 1;
 	}
 }
+
+@media (prefers-reduced-motion) {
+	.wrapper {
+		animation: none;
+	}
+}

--- a/src/views/Home/Home.module.css
+++ b/src/views/Home/Home.module.css
@@ -60,7 +60,8 @@ p {
 	font-weight: bold;
 	font:
 		600 16px/32px "Roboto",
-		"Arial" sans-serif;
+		"Arial",
+		sans-serif;
 	color: white;
 	background-color: #8900ff;
 	border-radius: 5px;
@@ -83,16 +84,19 @@ p {
 	width: 11rem;
 	font:
 		600 16px/32px "Roboto",
-		"Arial" sans-serif;
+		"Arial",
+		sans-serif;
 	color: #8900ff;
 	background-color: #fff;
 	border-radius: 5px;
 	border: 2px solid #e7e7e7;
 	font-weight: bold;
+	transition: border 0.3s ease;
 }
 
 .Visit:hover {
 	border: 2px solid #8900ff;
+	transition-duration: 0.4s;
 }
 
 .Visit:active {


### PR DESCRIPTION
The header animation is now disabled if the user prefers reduced motion. I also added a transition to the visit shop button since its hover state is the most different to it's normal state. It would be nice to have transitions on all the buttons but I figured it wasn't worth it since each is styled individually.

## When Reduced Motion is Preferred
![image](https://github.com/technative-academy/PetSynth/assets/16543008/62cec87a-adae-4d27-bcea-731f129dd72b)


## Unrelated Changes

 - Fixed a typo that made the font property on the homepage buttons to be invalid and so ignored. Is this what was intended?

### Before
![image](https://github.com/technative-academy/PetSynth/assets/16543008/c69d0f8f-3b74-4e54-8664-ca5a8b0007ec)


### After
![image](https://github.com/technative-academy/PetSynth/assets/16543008/4df13848-ed06-4012-8d0c-3253ac2073f8)

Resolves: https://trello.com/c/unuGMmLQ