### PR TITLE
Added mobile dimensions to ask and shop

### DIFF
--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -66,7 +66,7 @@
 
 .input {
 	margin: 10px;
-	width: 400px;
+	width: 325px;
 	height: 50px;
 	border-radius: 5px;
 	border: 1px solid #8900ff;
@@ -90,7 +90,7 @@
 
 .askbtn,
 .suggestbtn {
-	width: 400px;
+	width: 325px;
 	padding: 10px;
 	background: #8900ff;
 	border: none;

--- a/src/views/Shop/Shop.module.css
+++ b/src/views/Shop/Shop.module.css
@@ -43,7 +43,7 @@
 	border-top-left-radius: 30px;
 	z-index: 20px;
 	background-color: white;
-	width: 500px;
+	width: 355px;
 	padding-top: 50px;
 }
 
@@ -61,7 +61,7 @@
 
 .input {
 	margin: 10px;
-	width: 400px;
+	width: 325px;
 	height: 50px;
 	border-radius: 5px;
 	border: 1px solid #8900ff;
@@ -73,7 +73,7 @@
 }
 
 .searchbtn {
-	width: 400px;
+	width: 325px;
 	padding: 10px;
 	background: #8900ff;
 	border: none;
@@ -91,7 +91,7 @@
 	border: 1px solid #e7e7e7;
 	border-radius: 5px;
 	padding: 5px;
-	width: 400px;
+	width: 325px;
 }
 
 .select {
@@ -150,6 +150,7 @@
 	justify-content: center;
 	align-items: flex-start;
 	gap: 10px;
+	padding-left: 0px;
 }
 
 .productImg {
@@ -161,7 +162,6 @@
 
 .productcard {
 	/* border: 3px solid green; */
-	margin-right: 30px;
 	border-radius: 5px;
 	padding: 10px;
 }


### PR DESCRIPTION
We have gone down to a width of 375px (iPhone 11 + ) and fixed the mobile dimensions for ask page and the shop page. It's not perfect but it's a lot better. 

<img width="374" alt="Screenshot 2024-05-24 at 13 02 56" src="https://github.com/technative-academy/PetSynth/assets/156936136/bc9a1905-7084-4015-b9f2-0a81a97f58a9">

<img width="372" alt="Screenshot 2024-05-24 at 13 03 10" src="https://github.com/technative-academy/PetSynth/assets/156936136/fddbb4d8-40b8-4e77-bb40-e750d7b0f6f7">

<img width="375" alt="Screenshot 2024-05-24 at 13 03 21" src="https://github.com/technative-academy/PetSynth/assets/156936136/6889e047-5a67-47fa-bd75-4563c8811b85">

<img width="369" alt="Screenshot 2024-05-24 at 13 03 35" src="https://github.com/technative-academy/PetSynth/assets/156936136/6eeeb3a9-e3aa-4761-af22-20d3de29a416">

