### PR TITLE
Products Fix for Aspect Ratio of Final Images

### DIFF
--- a/src/views/Shop/Shop.module.css
+++ b/src/views/Shop/Shop.module.css
@@ -241,7 +241,7 @@
 	.productcard {
 		/* border: 3px solid green; */
 		width: 350px;
-		height: 400px;
+		height: auto;
 		margin-top: 50px;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
The aspect ratio of the images I generated is 1:1 rather than 3:2. I can crop them but we'll lose a lot of detail so I think this is probably better.

Before, with the new images:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/7460ff82-5d18-4e8e-b7d9-8bb803b8f18c)

Before, with the placeholder image:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/0b0dcaea-3bcc-484d-b974-182b15a1cbad)

After:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/c750e030-ca98-4aca-a1b9-09dbfc0c9e07)

## Comparisons for the unaffected mobile version

Before, with the new images:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/444e4d2d-2ce9-4329-b5fd-bce328b41eff)

Before, with the placeholder image:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/7769868c-9ded-4bb7-a290-f6acfdca74e3)

After:
![image](https://github.com/technative-academy/PetSynth/assets/16543008/96b8eae3-ea78-4b8b-ad9e-0c7fbf0143ff)

