### PR TITLE
I was inspired this Saturday afternoon: Page H1 Titles and Heros now render in the header

### DIFF
--- a/src/components/SiteHeader/SiteHeader.jsx
+++ b/src/components/SiteHeader/SiteHeader.jsx
@@ -46,10 +46,10 @@ function SiteHeader() {
 				return (
 					<div className={styles.viewHero}>
 						<h1>Buy the Pets</h1>
-						<p>
+						<h3>
 							We need to sell as many pets as possible to keep
 							PetSynth operating. Take your pick below!
-						</p>
+						</h3>
 					</div>
 				);
 			default:

--- a/src/components/SiteHeader/SiteHeader.jsx
+++ b/src/components/SiteHeader/SiteHeader.jsx
@@ -7,8 +7,6 @@ import styles from "./SiteHeader.module.css";
 function SiteHeader() {
 	const location = useLocation();
 
-	console.log(location.pathname);
-
 	const getHero = () => {
 		switch (location.pathname) {
 			case "/":

--- a/src/components/SiteHeader/SiteHeader.jsx
+++ b/src/components/SiteHeader/SiteHeader.jsx
@@ -6,7 +6,6 @@ import styles from "./SiteHeader.module.css";
 function SiteHeader() {
 	return (
 		<header className={styles.wrapper}>
-			<h2 className={styles.logo}>Petsynth</h2>
 			<SiteNav className={styles.siteNav} />
 		</header>
 	);

--- a/src/components/SiteHeader/SiteHeader.jsx
+++ b/src/components/SiteHeader/SiteHeader.jsx
@@ -1,12 +1,66 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 
 import SiteNav from "../SiteNav/SiteNav";
 import styles from "./SiteHeader.module.css";
 
 function SiteHeader() {
+	const location = useLocation();
+
+	console.log(location.pathname);
+
+	const getHero = () => {
+		switch (location.pathname) {
+			case "/":
+				return (
+					<div className={styles.viewHero}>
+						<h1> AI Pet Providers</h1>
+						<h3>
+							Pet generation service to find your puurfect virtual
+							customised companion
+						</h3>
+					</div>
+				);
+			case "/ask":
+				return (
+					<div className={styles.viewHero}>
+						<h1>Ask PetSynth</h1>
+						<h3>
+							Post an open-ended question here and see some
+							suggestions from our specially trained PetSynth
+							AI...
+						</h3>
+					</div>
+				);
+			case "/about":
+				return (
+					<div className={styles.viewHero}>
+						<h1>About PetSynth AI</h1>
+						<h3>
+							We make companions, and money, using your info, you
+							paid to give us!
+						</h3>
+					</div>
+				);
+			case "/shop":
+				return (
+					<div className={styles.viewHero}>
+						<h1>Buy the Pets</h1>
+						<p>
+							We need to sell as many pets as possible to keep
+							PetSynth operating. Take your pick below!
+						</p>
+					</div>
+				);
+			default:
+				return "Hi, here is your AI Cooking Assistant";
+		}
+	};
+
 	return (
 		<header className={styles.wrapper}>
 			<SiteNav className={styles.siteNav} />
+			{getHero()}
 		</header>
 	);
 }

--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -1,6 +1,6 @@
 /* Mobile header styling -- CSS gradient animation */
 .wrapper {
-	padding: 1rem 2rem;
+	padding: 1rem;
 	display: flex;
 	flex-direction: column;
 	gap: 2rem;
@@ -37,11 +37,8 @@
 @media (max-width: 530px) {
 	.wrapper {
 		height: 57vh;
-		padding: 1rem 1rem;
+		padding: 1rem;
 		gap: 1rem;
-	}
-
-	.siteNav {
 	}
 }
 
@@ -49,11 +46,9 @@
 
 @media (min-width: 768px) {
 	.wrapper {
+		padding: 2rem;
 		height: 55vh;
 		justify-content: flex-start;
-	}
-
-	.siteNav {
 	}
 }
 

--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -8,43 +8,42 @@
 	justify-content: flex-start;
 	color: white;
 	width: 100%;
-	height: 75vw;
+	height: 80vw;
 	background: linear-gradient(-45deg, #8900ff, #ffd700, #2e8b57, #8900ff);
 	background-size: 400% 400%;
 	animation: gradient 22s ease infinite;
 }
 
 .viewHero {
-	display: block;
-	text-align: center;
-	align-self: top;
-	/* color: red !important; */
-	/* font-size: 30px;
-	z-index: 99; */
-	/* margin: 0 !important; */
-	/* padding: 0 !important; */
+	display: flex;
+	flex-direction: column;
+	margin-top: 3rem;
+	align-items: center;
 }
 
 .viewHero h1 {
 	font:
-		900 56px/64px "Roboto",
+		900 32px/40px "Roboto",
 		"Arial",
 		sans-serif;
 	padding: 0 1rem;
 	margin: 0;
 	color: #fff;
 	background: transparent;
+	text-align: center;
 }
 
 .viewHero h3 {
 	font:
-		400 24px/36px "Roboto",
+		400 18px/24px "Roboto",
 		"Arial",
 		sans-serif;
 	padding: 1rem 1rem;
 	margin: 0;
 	text-align: left;
 	color: #fff;
+	text-align: center;
+	width: 32ch;
 }
 
 .siteNav {
@@ -69,9 +68,30 @@
 
 @media (max-width: 530px) {
 	.wrapper {
-		height: 57vh;
+		height: 110vw;
 		padding: 1rem;
 		gap: 1rem;
+	}
+}
+
+/* Table Sizing */
+
+@media (min-width: 600px) {
+	.logo {
+		font-size: 3rem;
+	}
+	.viewHero h1 {
+		font:
+			900 40px/48px "Roboto",
+			"Arial",
+			sans-serif;
+	}
+
+	.viewHero h3 {
+		font:
+			400 24px/36px "Roboto",
+			"Arial",
+			sans-serif;
 	}
 }
 
@@ -80,8 +100,21 @@
 @media (min-width: 768px) {
 	.wrapper {
 		padding: 2rem;
-		height: 55vh;
+		height: 30rem;
 		justify-content: flex-start;
+	}
+	.viewHero h1 {
+		font:
+			900 56px/64px "Roboto",
+			"Arial",
+			sans-serif;
+	}
+
+	.viewHero h3 {
+		font:
+			400 24px/36px "Roboto",
+			"Arial",
+			sans-serif;
 	}
 }
 

--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -2,28 +2,19 @@
 .wrapper {
 	padding: 1rem 2rem;
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	gap: 2rem;
-	align-items: flex-start;
-	justify-content: space-between;
+	align-items: center;
+	justify-content: flex-start;
 	color: white;
+	width: 100%;
 	height: 75vw;
 	background: linear-gradient(-45deg, #8900ff, #ffd700, #2e8b57, #8900ff);
 	background-size: 400% 400%;
 	animation: gradient 22s ease infinite;
 }
 
-.logo {
-	flex: 1;
-	font-family: "Orbitron", sans-serif;
-	font-weight: 900;
-	text-transform: uppercase;
-	font-size: 40px;
-}
-
 .siteNav {
-	flex: 1;
-	padding-right: 4vw;
 }
 
 @keyframes gradient {
@@ -50,14 +41,7 @@
 		gap: 1rem;
 	}
 
-	.logo {
-		/* margin-right: 500px; */
-		margin: 0;
-		font-size: 24px;
-	}
-
 	.siteNav {
-		flex: 1;
 	}
 }
 
@@ -66,18 +50,10 @@
 @media (min-width: 768px) {
 	.wrapper {
 		height: 55vh;
-		justify-content: space-evenly;
-	}
-
-	.logo {
-		/* margin-right: 500px; */
-		font-size: 64px;
-		margin-top: 1rem;
-		flex: 2;
+		justify-content: flex-start;
 	}
 
 	.siteNav {
-		flex: 1;
 	}
 }
 

--- a/src/components/SiteHeader/SiteHeader.module.css
+++ b/src/components/SiteHeader/SiteHeader.module.css
@@ -14,6 +14,39 @@
 	animation: gradient 22s ease infinite;
 }
 
+.viewHero {
+	display: block;
+	text-align: center;
+	align-self: top;
+	/* color: red !important; */
+	/* font-size: 30px;
+	z-index: 99; */
+	/* margin: 0 !important; */
+	/* padding: 0 !important; */
+}
+
+.viewHero h1 {
+	font:
+		900 56px/64px "Roboto",
+		"Arial",
+		sans-serif;
+	padding: 0 1rem;
+	margin: 0;
+	color: #fff;
+	background: transparent;
+}
+
+.viewHero h3 {
+	font:
+		400 24px/36px "Roboto",
+		"Arial",
+		sans-serif;
+	padding: 1rem 1rem;
+	margin: 0;
+	text-align: left;
+	color: #fff;
+}
+
 .siteNav {
 }
 

--- a/src/components/SiteNav/BurgerMenu/BurgerMenu.module.css
+++ b/src/components/SiteNav/BurgerMenu/BurgerMenu.module.css
@@ -8,7 +8,7 @@
 }
 
 .burger {
-	width: 2.8rem;
+	width: 2.95rem;
 	height: 0.25rem;
 	border-radius: 30px;
 	background-color: #fff;

--- a/src/components/SiteNav/SiteNav.jsx
+++ b/src/components/SiteNav/SiteNav.jsx
@@ -44,7 +44,7 @@ function SiteNav() {
 	//logic to display different format nav menu for mobile, to desktop, but also auto revert menu display style upon resize to larger
 	const getNavDisplay = () => {
 		if (isMobile) {
-			return burgerOpen ? "inline-flex" : "none";
+			return burgerOpen ? "flex" : "none";
 		} else {
 			return "flex";
 		}
@@ -55,26 +55,30 @@ function SiteNav() {
 			<Link to="/" className={styles.logoLink}>
 				<h2 className={styles.logo}>Petsynth</h2>
 			</Link>
-			<nav
-				className={styles.links}
-				style={{
-					display: getNavDisplay(),
-				}}
-			>
-				{navLinks.map((navLink) => (
-					<NavLink
-						key={navLink.url}
-						to={navLink.url}
-						className={({ isActive }) =>
-							isActive ? styles.activeLink : styles.inactiveLink
-						}
-					>
-						{navLink.label}
-					</NavLink>
-				))}
-			</nav>
-			<div className={styles.navBurgerMenu} onClick={toggleBurger}>
-				<BurgerMenu isOpen={burgerOpen} />
+			<div className={styles.navContainer}>
+				<div className={styles.navBurgerMenu} onClick={toggleBurger}>
+					<BurgerMenu isOpen={burgerOpen} />
+				</div>
+				<nav
+					className={styles.links}
+					style={{
+						display: getNavDisplay(),
+					}}
+				>
+					{navLinks.map((navLink) => (
+						<NavLink
+							key={navLink.url}
+							to={navLink.url}
+							className={({ isActive }) =>
+								isActive
+									? styles.activeLink
+									: styles.inactiveLink
+							}
+						>
+							{navLink.label}
+						</NavLink>
+					))}
+				</nav>
 			</div>
 		</div>
 	);

--- a/src/components/SiteNav/SiteNav.jsx
+++ b/src/components/SiteNav/SiteNav.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, Link } from "react-router-dom";
 
 import BurgerMenu from "./BurgerMenu/BurgerMenu";
 import styles from "./SiteNav.module.css";
@@ -52,6 +52,9 @@ function SiteNav() {
 
 	return (
 		<div className={styles.wrapper}>
+			<Link to="/" className={styles.logoLink}>
+				<h2 className={styles.logo}>Petsynth</h2>
+			</Link>
 			<nav
 				className={styles.links}
 				style={{

--- a/src/components/SiteNav/SiteNav.module.css
+++ b/src/components/SiteNav/SiteNav.module.css
@@ -41,7 +41,7 @@
 	line-height: 32px;
 	font-size: clamp(0.9rem, 1rem + 1vw, 3rem);
 	position: absolute;
-	top: 15%;
+	top: 11%;
 	left: 10%;
 	right: 10%;
 	width: auto;

--- a/src/components/SiteNav/SiteNav.module.css
+++ b/src/components/SiteNav/SiteNav.module.css
@@ -1,20 +1,27 @@
 /* Mobile Styling */
 .wrapper {
 	display: flex;
+	justify-self: center;
 	justify-content: space-between;
 	align-items: flex-start;
 	background: transparent;
-	padding: 1rem;
+	margin: 0;
 	width: 100%;
 }
 
+.navContainer {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+}
+
 .logo {
-	flex: 2;
+	flex: 1;
 	font-family: "Orbitron", sans-serif;
 	font-weight: 900;
 	text-transform: uppercase;
-	font-size: 40px;
-	margin: 0 auto;
+	font-size: 1.75rem;
+	margin: 0;
 	padding-top: 1rem;
 	width: auto;
 	color: white;
@@ -25,22 +32,29 @@
 }
 
 .links {
+	flex: 1;
 	display: flex;
 	flex-direction: row;
-	font:
-		400 16px/24px "Roboto",
-		sans-serif;
-	margin-top: 2vw;
+	justify-content: center;
+	font-weight: 400;
+	font-family: "Roboto", sans-serif;
+	line-height: 32px;
+	font-size: clamp(0.9rem, 1rem + 1vw, 3rem);
+	position: absolute;
+	top: 15%;
+	height: 20%;
+	left: 10%;
+	right: 10%;
 	width: auto;
 	z-index: 10;
 }
 
 .activeLink,
 .inactiveLink {
-	padding: 2px;
+	padding: 0.2rem;
 	list-style: none;
 	text-decoration: none;
-	margin: 0 0 0 1.5rem;
+	margin: 0 0.5rem;
 }
 
 .activeLink {
@@ -85,16 +99,21 @@
 /* Mobile Hamburger Nav Styling */
 
 .navBurgerMenu {
-	display: fixed;
+	display: flex;
 	padding-top: 1rem;
 	margin-left: 1rem;
 	z-index: 10;
 }
 
+@media (min-width: 600px) {
+	.logo {
+		font-size: 3rem;
+	}
+}
+
 /* Desktop styling */
 @media (min-width: 768px) {
 	.wrapper {
-		padding: 1rem;
 		display: flex;
 		flex-direction: row;
 		align-items: flex-start;
@@ -111,9 +130,11 @@
 	.links {
 		display: flex;
 		flex-direction: row;
+		justify-content: center;
+		position: static;
 		gap: 2rem;
 		font:
-			16px/24px "Roboto",
+			400 16px/24px "Roboto",
 			sans-serif;
 		margin: 0;
 		background-color: transparent;

--- a/src/components/SiteNav/SiteNav.module.css
+++ b/src/components/SiteNav/SiteNav.module.css
@@ -1,22 +1,37 @@
 /* Mobile Styling */
 .wrapper {
 	display: flex;
-	flex-direction: column-reverse;
-	align-items: center;
-	justify-content: center;
+	justify-content: space-between;
+	align-items: flex-start;
 	background: transparent;
+	padding: 1rem;
+	width: 100%;
+}
+
+.logo {
+	flex: 2;
+	font-family: "Orbitron", sans-serif;
+	font-weight: 900;
+	text-transform: uppercase;
+	font-size: 40px;
+	margin: 0 auto;
+	padding-top: 1rem;
+	width: auto;
+	color: white;
+}
+
+.logoLink {
+	text-decoration: none;
 }
 
 .links {
 	display: flex;
-	align-self: center;
-
+	flex-direction: row;
 	font:
 		400 16px/24px "Roboto",
 		sans-serif;
 	margin-top: 2vw;
-	margin-left: -100%;
-	width: 100%;
+	width: auto;
 	z-index: 10;
 }
 
@@ -79,11 +94,19 @@
 /* Desktop styling */
 @media (min-width: 768px) {
 	.wrapper {
-		padding: 0.5rem;
+		padding: 1rem;
 		display: flex;
-		align-items: center;
-		justify-content: center;
+		flex-direction: row;
+		align-items: flex-start;
+		justify-content: space-between;
 		background: transparent;
+	}
+
+	.logo {
+		/* margin-right: 500px; */
+		font-size: 64px;
+		margin: 0 auto;
+		flex: 1;
 	}
 	.links {
 		display: flex;

--- a/src/components/SiteNav/SiteNav.module.css
+++ b/src/components/SiteNav/SiteNav.module.css
@@ -42,7 +42,6 @@
 	font-size: clamp(0.9rem, 1rem + 1vw, 3rem);
 	position: absolute;
 	top: 15%;
-	height: 20%;
 	left: 10%;
 	right: 10%;
 	width: auto;

--- a/src/views/About/About.jsx
+++ b/src/views/About/About.jsx
@@ -10,7 +10,8 @@ function About() {
 	return (
 		<div className={styles.wrapper}>
 			<div className={styles.aboutWrapper}>
-				<AboutHero />
+				{/* AboutHero surplus to requirements after header-page title refactor* - cg/}
+				{/* <AboutHero /> */}
 				<div className={styles.aboutContentBox}>
 					<Tabs
 						tabs={[

--- a/src/views/About/About.module.css
+++ b/src/views/About/About.module.css
@@ -1,6 +1,4 @@
-/* Mobile First */
-
-.wrapper {
+Mobile First .wrapper {
 	background: white;
 	width: 100%;
 	display: flex;
@@ -32,7 +30,7 @@
 	margin-top: -220px;
 }
 
-.aboutHero {
+/* .aboutHero {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -40,18 +38,18 @@
 	margin-top: -1.25rem;
 	margin-bottom: 3rem;
 	padding: 0;
-}
+} */
 
-.aboutH1 {
+/* .aboutH1 {
 	margin-top: 0;
-}
+} */
 
-.aboutH3 {
+/* .aboutH3 {
 	max-width: 35ch;
 	margin-left: 1rem;
 	margin: 0 auto;
 	text-align: center;
-}
+} */
 /*  Potentially release if we get round to improving specificity of Home view selectors - class versus element
 .aboutp {
 	font:
@@ -78,7 +76,7 @@
 		background-color: white;
 	}
 
-	.aboutHero {
+	/* .aboutHero {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -86,5 +84,5 @@
 		margin-top: -5.25rem;
 		margin-bottom: 3rem;
 		padding: 0;
-	}
+	} */
 }

--- a/src/views/About/About.module.css
+++ b/src/views/About/About.module.css
@@ -13,8 +13,8 @@ Mobile First .wrapper {
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	margin: -1.75rem;
-	padding: 1rem;
+	margin-top: 7.5rem;
+	padding: 2rem;
 	border-top-right-radius: 1.8rem;
 	border-top-left-radius: 1.8rem;
 	z-index: 20;
@@ -71,7 +71,7 @@ Mobile First .wrapper {
 		max-width: 1000px;
 		box-shadow: 0px 0px 20px 0px rgba(27, 28, 34, 0.1);
 		margin-bottom: 12vh;
-		margin-top: 1.5rem;
+		margin-top: 8.75rem;
 		z-index: 20;
 		background-color: white;
 	}

--- a/src/views/Ask/Ask.jsx
+++ b/src/views/Ask/Ask.jsx
@@ -8,13 +8,14 @@ function Ask() {
 	return (
 		<div className={styles.wrapper}>
 			{/* Hero container content needs to overlap header */}
-			<div className={styles.herocontainer}>
+			{/* Below jsx is surplus after header-title refactor - cg */}
+			{/* <div className={styles.herocontainer}>
 				<h1 className={styles.h1}>Ask PetSynth</h1>
 				<p className={styles.herodesc}>
 					Post an open-ended question here and see some suggestions
 					from our specially trained PetSynth AI...
 				</p>
-			</div>
+			</div> */}
 			<AskForm />
 			<AskResults />
 		</div>

--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -221,8 +221,8 @@
 		padding: 20px;
 		max-width: 1000px;
 		box-shadow: 0px 0px 20px 0px rgba(27, 28, 34, 0.1);
-		margin-bottom: 0px;
-		margin-top: -180px;
+		margin-bottom: 13.2rem;
+		/* margin-top: -180px; */
 		z-index: 20px;
 		background-color: white;
 		/* border: 2px solid green; */
@@ -270,6 +270,7 @@
 		width: 1000px;
 		box-shadow: 0px 0px 20px 0px rgba(27, 28, 34, 0.1);
 		border-radius: 5px;
+		margin-top: -13rem;
 	}
 
 	.resultsContainer {

--- a/src/views/Ask/Ask.module.css
+++ b/src/views/Ask/Ask.module.css
@@ -20,6 +20,8 @@
 
 /* Page hero container and content styling -- might move later */
 
+/* Below surplus after header - title refactor - cg
+
 .herocontainer {
 	display: flex;
 	flex-direction: column;
@@ -44,7 +46,7 @@
 	color: white;
 	margin-bottom: 50px;
 	font-size: 18px;
-}
+} */
 
 /* Ask page container styling */
 
@@ -182,7 +184,9 @@
 
 /* Desktop styling */
 @media (min-width: 768px) {
-	/* Ask Page Desktop styling */
+	/* Ask Page Desktop styling 
+
+	h1 + hero styling surplus after header title refactor - cg
 	.h1 {
 		font-size: 40px;
 	}
@@ -190,6 +194,7 @@
 	.herodesc {
 		padding-bottom: 100px;
 	}
+	*/
 
 	.resultsheading {
 		color: #1b1c22;

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -14,13 +14,6 @@ function Home() {
 	*/
 	return (
 		<div className={styles.wrapper}>
-			<div className={styles.contentBoxOne}>
-				<h1> AI Pet Providers</h1>
-				<h3>
-					Pet generation service to find your puurfect virtual
-					customised companion
-				</h3>
-			</div>
 			<div className={styles.primaryContentContainer}>
 				<div className={styles.contentBoxTwo}>
 					<h2>

--- a/src/views/Home/Home.module.css
+++ b/src/views/Home/Home.module.css
@@ -1,17 +1,5 @@
 /* 'MOBILE' VIEWPORTS < 768px */
 
-h1 {
-	font:
-		900 40px/48px "Roboto",
-		"Arial",
-		sans-serif;
-	padding: 0 1rem;
-	margin: 0;
-	color: #fff;
-	background: transparent;
-	margin-top: -15rem;
-}
-
 h2 {
 	font:
 		600 32px/40px "Roboto",
@@ -20,17 +8,6 @@ h2 {
 	padding: 0 1rem;
 	margin: 0;
 	text-align: left;
-}
-
-h3 {
-	font:
-		600 20px/28px "Roboto",
-		"Arial",
-		sans-serif;
-	padding: 1rem 1rem;
-	margin: 0;
-	text-align: left;
-	color: #fff;
 }
 
 h4 {
@@ -127,27 +104,6 @@ p {
 	width: 100%;
 }
 
-/* .boxTop {
-	background-color: #fff;
-	height: 3rem;
-	border-radius: 1.25rem 1.25rem 0px 0px;
-	margin-top: -2rem;
-	width: 100%;
-	z-index: 20;
-	display: block;
-} */
-
-.contentBoxOne {
-	flex: 1;
-	padding: 0rem 1rem;
-	text-align: center;
-	width: 100%;
-}
-
-.contentBoxOne h3 {
-	text-align: center;
-	align-self: center;
-}
 .contentBoxTwo {
 	flex: 1;
 	padding: 0 1rem;
@@ -199,12 +155,6 @@ p {
 		z-index: 20;
 		background-color: white;
 	}
-	.contentBoxOne {
-		flex: 1;
-		padding: 0rem 1rem;
-		text-align: center;
-		max-width: 70vw;
-	}
 
 	.contentBoxTwo {
 		grid-area: 1 / 1 / 2 / 2;
@@ -242,17 +192,6 @@ p {
 		margin: 1rem auto;
 	}
 
-	h1 {
-		font:
-			900 56px/64px "Roboto",
-			"Arial",
-			sans-serif;
-		padding: 0 1rem;
-		margin: 0;
-		color: #fff;
-		background: transparent;
-		margin-top: -19rem;
-	}
 	h2 {
 		font:
 			600 32px/40px "Roboto",
@@ -261,17 +200,6 @@ p {
 		padding: 0 1rem;
 		margin: 0;
 		text-align: left;
-	}
-
-	h3 {
-		font:
-			400 24px/36px "Roboto",
-			"Arial",
-			sans-serif;
-		padding: 1rem 1rem;
-		margin: 0;
-		text-align: left;
-		color: #fff;
 	}
 
 	h4 {

--- a/src/views/Shop/Shop.jsx
+++ b/src/views/Shop/Shop.jsx
@@ -10,13 +10,14 @@ function Shop() {
 
 	return (
 		<div className={styles.wrapper}>
-			<div className={styles.herocontainer}>
+			{/* Below JSX is surplus after header-title refactor by cg */}
+			{/* <div className={styles.herocontainer}>
 				<h1 className={styles.herotitle}>Buy the Pets</h1>
 				<p className={styles.herodesc}>
 					We need to sell as many pets as possible to keep PetSynth
 					operating. Take your pick below!
 				</p>
-			</div>
+			</div> */}
 			<div className={styles.searchcomponent}>
 				<Search onSubmit={handleSearchSubmit} />
 				<ProductResults query={activeQuery} sortMode={activeSortMode} />

--- a/src/views/Shop/Shop.module.css
+++ b/src/views/Shop/Shop.module.css
@@ -9,7 +9,9 @@
 	align-items: center;
 }
 
-/* Page hero container and content styling -- might move later */
+/* Page hero container and content styling -- might move later 
+
+hero styling surplus after header-title refactor by cg
 
 .herocontainer {
 	display: flex;
@@ -29,6 +31,7 @@
 	color: white;
 	font-size: 20px;
 }
+*/
 
 /* Shop page container styling */
 
@@ -178,6 +181,9 @@
 
 /* Desktop styling */
 @media (min-width: 768px) {
+	/* 
+	header-hero-h1 styling is surplus after header-title refactor by cg
+	
 	h1 {
 		font-size: 40px;
 	}
@@ -185,7 +191,7 @@
 	.herocontainer {
 		display: flex;
 		flex-direction: column;
-	}
+	} */
 
 	.productcontainer {
 		display: flex;


### PR DESCRIPTION
so I'd been poking around the other teams sites and had inspiration from their code: as such page views no longer rely on pushed margins for the _title_ or _hero_ blurby bit

`useLocation() `and `case`  logic to determine the page and render the appropriate `H1` and `H3` was plugged into **SiteHeader.jsx** if you want to hunt for it

Then I had to go into all the page 'views' (i.e. home, about ...etc) and pull/comment out the associated .jsx and .css

Then readjusted all those negative margins to compensate.

Also improved display of popout burger-nav.

fingers in all the files.

NB @hedgehog125 @sfbennett  If you don't want to accept it without lots of changes , then we just don't need to bother, iIm not going to do any more this weekend , so if it's got lots of changes you want made, just reject it and we can leave the site as-is
**This is me playing, taken slow old me 5 hours! I think it's an improvement. approve or don't approve. I'm happy to just apply it to my fork after presentation otherwise.**

![Screenshot from 2024-05-25 22-08-52](https://github.com/technative-academy/PetSynth/assets/143351775/997db746-ba79-4136-b18d-5aba6fa7cfee)
![Screenshot 2024-05-25 at 22-09-43 PetSynth AI Assisted Companions](https://github.com/technative-academy/PetSynth/assets/143351775/4ca5142a-a821-4768-9b81-eafc7c2e9f43)
![Screenshot 2024-05-25 at 22-09-25 PetSynth AI Assisted Companions](https://github.com/technative-academy/PetSynth/assets/143351775/4f217355-843a-460e-a719-750f5b183bf8)
![Screenshot from 2024-05-25 22-08-52](https://github.com/technative-academy/PetSynth/assets/143351775/997db746-ba79-4136-b18d-5aba6fa7cfee)
